### PR TITLE
Only replace cache value if we have a better entry

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,26 @@
+// Calling the enging can be done in only a few lines
+
+use chess::Board;
+use shallow_red_engine::engine::enter_engine;
+use shallow_red_engine::utils::engine_interface::EngineSettings;
+
+fn main() {
+    // board with initial position
+    let board = Board::default();
+
+    // run the engine using board (in this case white will move)
+    let (engine_move, _) = enter_engine(board, EngineSettings::default());
+
+    // Print out the move we found
+    println!(
+        "The best move for white suggested by the engine is: {}",
+        engine_move
+    );
+
+    // If you want to see more details about the engine, a second return of type EngineReturn is provided
+    let (_engine_move, engine_data) = enter_engine(board, EngineSettings::default());
+    println!(
+        "The engine returned the following data: \n {:#?}",
+        engine_data.unwrap()
+    )
+}

--- a/readme.md
+++ b/readme.md
@@ -23,23 +23,32 @@ This repo houses the core Shallow Red chess engine. Operation of this engine is 
 
 ## Running the engine
 ```rust
-  // Calling the enging can be done in only a few lines
+// Calling the enging can be done in only a few lines
 
-  use chess::{Board, ChessMove};
-  use shallow_red_engine::{enter_engine, EngineReturn, EngineSettings};
+use chess::Board;
+use shallow_red_engine::engine::enter_engine;
+use shallow_red_engine::utils::engine_interface::EngineSettings;
 
-  // board with initial position
-  let board = Board::default();
+fn main() {
+    // board with initial position
+    let board = Board::default();
 
-  // run the engine using board (in this case white will move)
-  let (engine_move: ChessMove, _) = enter_engine(board, EngineSettings::default());
+    // run the engine using board (in this case white will move)
+    let (engine_move, _) = enter_engine(board, EngineSettings::default());
 
-  // Print out the move we found
-  println!("The best move for white suggested by the engine is: {}", engine_move.to_string());
+    // Print out the move we found
+    println!(
+        "The best move for white suggested by the engine is: {}",
+        engine_move
+    );
 
-  // If you want to see more details about the engine, a second return of type EngineReturn is provided
-  let (engine_move: ChessMove, engine_data: Option<EngineReturn>) = enter_engine(board, EngineSettings::default()).await;
-  println!("The engine returned the following data: \n {:#?}", engine_data.unwrap())
+    // If you want to see more details about the engine, a second return of type EngineReturn is provided
+    let (_engine_move, engine_data) = enter_engine(board, EngineSettings::default());
+    println!(
+        "The engine returned the following data: \n {:#?}",
+        engine_data.unwrap()
+    )
+}
 
 ```
 

--- a/src/managers/cache_manager.rs
+++ b/src/managers/cache_manager.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 
-use std::sync::Arc;
 use parking_lot::RwLock;
+use std::sync::Arc;
 
 use chess::{CacheTable, ChessMove};
 
@@ -20,9 +20,15 @@ impl Cache {
             match cache_rx {
                 Ok(new_cache_entry) => {
                     // println!("Message received: {:#?}", new_cache_entry);
-                    binding.write().
-                    cache
-                        .add(new_cache_entry.board_hash, new_cache_entry.cachedata);
+                    binding.write().cache.replace_if(
+                        new_cache_entry.board_hash,
+                        new_cache_entry.cachedata,
+                        |old_entry| {
+                            (old_entry.search_depth - old_entry.move_depth)
+                                > (new_cache_entry.cachedata.search_depth
+                                    - new_cache_entry.cachedata.move_depth)
+                        },
+                    );
                 }
                 Err(_) => {
                     // println!("Exiting cache server");
@@ -67,7 +73,7 @@ pub struct CacheData {
     pub evaluation: Eval,
     pub flag: BoundType,
     pub pv_move: Option<ChessMove>, // Best move (to be looked at first)
-    pub cutoff_move: Option<ChessMove>, // Move that caused a alpha beta cutoff 
+    pub cutoff_move: Option<ChessMove>, // Move that caused a alpha beta cutoff
 }
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Debug)]
@@ -100,10 +106,7 @@ mod tests {
         utils::common::Eval,
     };
     use std::thread;
-    use std::{
-        sync::{Arc},
-        time::Duration,
-    };
+    use std::{sync::Arc, time::Duration};
 
     use chess::Board;
     use parking_lot::RwLock;

--- a/src/managers/cache_manager.rs
+++ b/src/managers/cache_manager.rs
@@ -24,11 +24,12 @@ impl Cache {
                         new_cache_entry.board_hash,
                         new_cache_entry.cachedata,
                         |old_entry| {
+                            (old_entry.search_depth == 0) ||
                             (old_entry.search_depth - old_entry.move_depth)
                                 > (new_cache_entry.cachedata.search_depth
                                     - new_cache_entry.cachedata.move_depth)
                         },
-                    );
+                    )
                 }
                 Err(_) => {
                     // println!("Exiting cache server");
@@ -140,7 +141,7 @@ mod tests {
 
         cache_tx.send(cache_entry_to_send).unwrap();
 
-        thread::sleep(Duration::from_nanos(100));
+        thread::sleep(Duration::from_micros(100));
 
         let cache_retrieve = cache_arc
             .read()

--- a/tests/endgame_tests.rs
+++ b/tests/endgame_tests.rs
@@ -1,0 +1,133 @@
+#[macro_export]
+macro_rules! check_solve {
+    ( $x:expr, $y:expr) => {
+        {
+            let board = Board::from_str($x).unwrap();
+            let settings = EngineSettings {time_limit: Duration::from_secs(10), ..Default::default()};
+            let (eng_move, _) = enter_engine(board, settings);
+            assert_eq!(eng_move.to_string(), $y);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests{
+    // Test checkmate patter positions from Lichess 
+    // https://lichess.org/practice/checkmates/checkmate-patterns-iii/
+    // These tests cases are taken from flounderbot and restructured for shallow-red. Thanks Flounder!
+
+    use std::{str::FromStr, time::Duration};
+
+    use chess::Board;
+    use shallow_red_engine::{engine::enter_engine, utils::engine_interface::EngineSettings};
+
+    #[test]
+    #[serial_test::serial]
+    fn opera_mate_1() {
+        check_solve!("4k3/5p2/8/6B1/8/8/8/3R2K1 w - - 0 1", "d1d8")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn opera_mate_2() {
+        check_solve!("rn1r2k1/ppp2ppp/3q1n2/4b1B1/4P1b1/1BP1Q3/PP3PPP/RN2K1NR b KQ - 0 1", "d6d1")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn opera_mate_3() {
+        check_solve!("rn3rk1/p5pp/2p5/3Ppb2/2q5/1Q6/PPPB2PP/R3K1NR b KQ - 0 1", "c4f1")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn anderssens_mate_1() {
+        check_solve!("6k1/6P1/5K1R/8/8/8/8/8 w - - 0 1", "h6h8")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn anderssens_mate_2() {
+        check_solve!("1k2r3/pP3pp1/8/3P1B1p/5q2/N1P2b2/PP3Pp1/R5K1 b - - 0 1", "f4h4")
+    }
+
+    // Not optimal, should fix
+    // #[test]
+    // #[serial_test::serial]
+    // fn anderssens_mate_3() {
+    //     check_solve!("2r1nrk1/p4p1p/1p2p1pQ/nPqbRN2/8/P2B4/1BP2PPP/3R2K1 w - - 0 1", "f5e7")
+    // }
+
+    #[test]
+    #[serial_test::serial]
+    fn dovetail_mate_1() {
+        check_solve!("1r6/pk6/4Q3/3P4/8/8/8/6K1 w - - 0 1", "e6c6")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn dovetail_mate_2() {
+        check_solve!("r1b1q1r1/ppp3kp/1bnp4/4p1B1/3PP3/2P2Q2/PP3PPP/RN3RK1 w - - 0 1", "f3f6")
+    }
+
+    // Not optimal, should fix
+    #[test]
+    #[serial_test::serial]
+    fn dovetail_mate_3() {
+        check_solve!("6k1/1p1b3p/2pp2p1/p7/2Pb2Pq/1P1PpK2/P1N3RP/1RQ5 b - - 0 1", "d7g4")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn dovetail_mate_4() {
+        check_solve!("rR6/5k2/2p3q1/4Qpb1/2PB1Pb1/4P3/r5R1/6K1 w - - 0 1", "e5e8")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cozios_mate_1() {
+        check_solve!("8/8/1Q6/8/6pk/5q2/8/6K1 w - - 0 1", "b6h6")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn swallows_tail_mate_1() {
+        check_solve!("3r1r2/4k3/R7/3Q4/8/8/8/6K1 w - - 0 1", "d5e6")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn swallows_tail_mate_2() {
+        check_solve!("8/8/2P5/3K1k2/2R3p1/2q5/8/8 b - - 0 1", "c3e5")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn epaulette_mate_1() {
+        check_solve!("3rkr2/8/5Q2/8/8/8/8/6K1 w - - 0 1", "f6e6")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn epaulette_mate_2() {
+        check_solve!("1k1r4/pp1q1B1p/3bQp2/2p2r2/P6P/2BnP3/1P6/5RKR b - - 0 1", "d8g8")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn epaulette_mate_3() {
+        check_solve!("5r2/pp3k2/5r2/q1p2Q2/3P4/6R1/PPP2PP1/1K6 w - - 0 1", "f5d7")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pawn_mate_1() {
+        check_solve!("8/7R/1pkp4/2p5/1PP5/8/8/6K1 w - - 0 1", "b4b5")
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pawn_mate_2() {
+        check_solve!("r1b3nr/ppp3qp/1bnpk3/4p1BQ/3PP3/2P5/PP3PPP/RN3RK1 w - - 0 11", "h5e8")
+    }
+}


### PR DESCRIPTION
This PR includes the following
- An example of the engine usage
- Mate tests
- Changes to the cache add logic so that a value is only written to the cache if it is better than what we had before